### PR TITLE
Allow libneon 34

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_PROG_LN_S
 # Checks for libraries.
 AM_GNU_GETTEXT_VERSION(0.19.8)
 AM_GNU_GETTEXT([external])
-NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32 33])
+NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32 33 34])
 DAV_CHECK_NEON
 
 # Checks for header files.


### PR DESCRIPTION
Version 0.34.0 of libneon was released some three weeks ago, and has already been packaged in debian unstable. For this reason, building davfs2 in unstable requires libneon version 0.34.0 to be allowed.

This simple PR does just that.

Best,

Aymeric