### PR TITLE
Allow setting a mount password via an env var DAVFS_PASSWORD

### DIFF
--- a/man/mount.davfs.8
+++ b/man/mount.davfs.8
@@ -462,6 +462,14 @@ WebDAV resource a subdirectory is created.
 .SH ENVIRONMENT
 
 .TP
+.B DAVFS_PASSWORD
+If set, this environment variable will be used as the password for WebDAV
+authentication if no password is specified via the command line option and
+in preference to anything found in  secrets files. This allows for scripted
+mounting without storing passwords in files or exposing them in command
+line arguments; especially relevant in the context of CI runners.
+
+.TP
 .B https_proxy http_proxy all_proxy
 If no proxy is defined in the configuration file the value is taken from
 this environment variables. The proxy may be given with or without scheme


### PR DESCRIPTION
This effectively allows a CI runner with a password in a secret environment variable not exposed in the project sources to mount a DAVFS mount without trying to hide it from the terminal output while using it as an argument or getting the variable written to a temparary file.
