### PR TITLE
Amend NE_REQUIRE_VERSIONS for neon v0.35.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_PROG_LN_S
 # Checks for libraries.
 AM_GNU_GETTEXT_VERSION(0.19.8)
 AM_GNU_GETTEXT([external])
-NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32 33 34])
+NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32 33 34 35])
 DAV_CHECK_NEON
 
 # Checks for header files.


### PR DESCRIPTION
neon v0.35.0 released 15 July 2025.  davfs2 builds just fine using it.  Here's the simplest PR I've ever submitted.