### PR TITLE
meson.build: check error.h & -lerror is not required

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -5,5 +5,7 @@ install_man('davfs2.conf.5',
 
 run_command('po4a', 'po4a.conf', check:true)
 
-subdir('de')
-subdir('es')
+if get_variable('enable_nls')
+  subdir('de')
+  subdir('es')
+endif

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,20 @@ cdata.set_quoted('DAV_CERTS_DIR', davfs2_certdir)
 cdata.set_quoted('DAV_SECRETS', 'secrets')
 cdata.set_quoted('PACKAGE_BUGREPORT', 'https://github.com/alisarctl/davfs2')
 
+enable_nls = false
+
+if get_option('nls')
+  msgfmt = find_program('msgfmt', required: false)
+  if msgfmt.found()
+    enable_nls = true
+    localedir = join_paths(get_option('datadir'), 'locale')
+    cdata.set_quoted('LOCALEDIR', localedir)
+  endif
+endif
+
+set_variable('enable_nls', enable_nls)
+cdata.set('ENABLE_NLS', enable_nls)
+
 system_headers = [
   'dirent.h',
   'fcntl.h',
@@ -120,7 +134,9 @@ run_command('po4a', '--version', check : true)
 
 subdir('src')
 subdir('etc')
+if enable_nls
 subdir('po')
+endif
 if get_option('man') == true
 subdir('man')
 endif

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,6 @@ davfs2_sbindir = prefix / get_option('sbindir')
 davfs2_sysconfdir = prefix / get_option('sysconfdir') / meson.project_name()
 davfs2_localstatedir = get_option('statedir')
 davfs2_datadir = prefix / get_option('datadir')
-davfs2_docdir = davfs2_datadir / 'doc' / meson.project_name()
 davfs2_sharedir = prefix / davfs2_datadir / meson.project_name()
 
 davfs2_certdir = get_option('certdir')
@@ -154,10 +153,19 @@ doc_files = ['AUTHORS',
 ]
 
 if get_option('doc') == true
-davfs2_doc_files = install_data(
-  doc_files,
-  install_dir : davfs2_docdir
-)
+
+  docdir_option = get_option('docdir')
+
+  if docdir_option == ''
+    davfs2_docdir = davfs2_datadir / 'doc' / meson.project_name()
+  else
+    davfs2_docdir = docdir_option
+  endif
+
+  davfs2_doc_files = install_data(
+    doc_files,
+    install_dir : davfs2_docdir
+  )
 endif
 
 summary({

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,6 @@ cdata.set_quoted('PACKAGE_BUGREPORT', 'https://github.com/alisarctl/davfs2')
 
 system_headers = [
   'dirent.h',
-  'error.h',
   'fcntl.h',
   'iconv.h',
   'libintl.h',
@@ -101,6 +100,12 @@ if meson.version().version_compare('>= 1.3.0')
   endforeach
 
   cc.has_function('canonicalize_file_name')
+
+  if cc.has_header('error.h') and cc.has_function('error', prefix: '#include <error.h>')
+    # has error.h and -lerror (if on musl) is not required
+    cdata.set('HAVE_ERROR_H', 1)
+  endif
+
 endif
 
 configure_file(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,4 +5,4 @@ option('statedir', type : 'string', value : '/var/run', description : 'state dir
 option('certdir', type : 'string', value : 'certs', description : 'Relative cert directory to sysconfdir')
 option('dav_user', type : 'string', value : 'davfs2', description : 'if invoked by root, mount.davfs runs as this user')
 option('dav_group', type : 'string', value : 'davfs2', description : 'the group, the mount.davfs daemon belongs to')
-
+option('nls', type : 'boolean', value : true, description : 'Enable Native Language Support (NLS)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('man', type : 'boolean', value : true, description : 'generate and install man pages')
 option('doc', type : 'boolean', value : true, description : 'install documentation')
+option('docdir', type : 'string', value : '', description : 'documentation dir')
 option('cachedir', type : 'string', value : '/var/cache/davfs2', description : 'cache dir')
 option('statedir', type : 'string', value : '/var/run', description : 'state dir')
 option('certdir', type : 'string', value : 'certs', description : 'Relative cert directory to sysconfdir')


### PR DESCRIPTION
musl has error-standalone which provide error.h, but -lerror is required for a success build, so only define HAVE_ERROR_H if both error.h exist and can be linked without "-lerror".